### PR TITLE
[CloudKitty] Add osp-secret as the default for secret

### DIFF
--- a/api/bases/telemetry.openstack.org_cloudkitties.yaml
+++ b/api/bases/telemetry.openstack.org_cloudkitties.yaml
@@ -576,6 +576,7 @@ spec:
                   Needed to request a transportURL that is created and used in CloudKitty
                 type: string
               secret:
+                default: osp-secret
                 description: Secret containing OpenStack password information
                 type: string
               serviceUser:

--- a/api/bases/telemetry.openstack.org_cloudkittyapis.yaml
+++ b/api/bases/telemetry.openstack.org_cloudkittyapis.yaml
@@ -325,6 +325,7 @@ spec:
                     type: object
                 type: object
               secret:
+                default: osp-secret
                 description: Secret containing OpenStack password information
                 type: string
               serviceAccount:

--- a/api/bases/telemetry.openstack.org_cloudkittyprocs.yaml
+++ b/api/bases/telemetry.openstack.org_cloudkittyprocs.yaml
@@ -180,6 +180,7 @@ spec:
                     type: object
                 type: object
               secret:
+                default: osp-secret
                 description: Secret containing OpenStack password information
                 type: string
               serviceAccount:

--- a/api/bases/telemetry.openstack.org_telemetries.yaml
+++ b/api/bases/telemetry.openstack.org_telemetries.yaml
@@ -1141,6 +1141,7 @@ spec:
                       Needed to request a transportURL that is created and used in CloudKitty
                     type: string
                   secret:
+                    default: osp-secret
                     description: Secret containing OpenStack password information
                     type: string
                   serviceUser:

--- a/api/v1beta1/cloudkitty_types.go
+++ b/api/v1beta1/cloudkitty_types.go
@@ -146,6 +146,7 @@ type CloudKittyTemplate struct {
 	DatabaseAccount string `json:"databaseAccount"`
 
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=osp-secret
 	// Secret containing OpenStack password information
 	Secret string `json:"secret"`
 

--- a/config/crd/bases/telemetry.openstack.org_cloudkitties.yaml
+++ b/config/crd/bases/telemetry.openstack.org_cloudkitties.yaml
@@ -576,6 +576,7 @@ spec:
                   Needed to request a transportURL that is created and used in CloudKitty
                 type: string
               secret:
+                default: osp-secret
                 description: Secret containing OpenStack password information
                 type: string
               serviceUser:

--- a/config/crd/bases/telemetry.openstack.org_cloudkittyapis.yaml
+++ b/config/crd/bases/telemetry.openstack.org_cloudkittyapis.yaml
@@ -325,6 +325,7 @@ spec:
                     type: object
                 type: object
               secret:
+                default: osp-secret
                 description: Secret containing OpenStack password information
                 type: string
               serviceAccount:

--- a/config/crd/bases/telemetry.openstack.org_cloudkittyprocs.yaml
+++ b/config/crd/bases/telemetry.openstack.org_cloudkittyprocs.yaml
@@ -180,6 +180,7 @@ spec:
                     type: object
                 type: object
               secret:
+                default: osp-secret
                 description: Secret containing OpenStack password information
                 type: string
               serviceAccount:

--- a/config/crd/bases/telemetry.openstack.org_telemetries.yaml
+++ b/config/crd/bases/telemetry.openstack.org_telemetries.yaml
@@ -1141,6 +1141,7 @@ spec:
                       Needed to request a transportURL that is created and used in CloudKitty
                     type: string
                   secret:
+                    default: osp-secret
                     description: Secret containing OpenStack password information
                     type: string
                   serviceUser:


### PR DESCRIPTION
  When the secret is unset, cloudkitty will not start, since there was no
  default set.
   
  The osp-secret is used as the default secret for other services.
    
  The default value for the cloudkitty secret is updated to match the
  other service defaults, since the required information (CK password)
  is expected to be in the same secret as the other services.
