### PR TITLE
[cloudkitty] FIx pod startup issues

### DIFF
--- a/pkg/cloudkittyapi/statefulset.go
+++ b/pkg/cloudkittyapi/statefulset.go
@@ -48,14 +48,14 @@ func StatefulSet(
 	livenessProbe := &corev1.Probe{
 		// TODO might need tuning
 		TimeoutSeconds:      5,
-		PeriodSeconds:       3,
-		InitialDelaySeconds: 5,
+		PeriodSeconds:       5,
+		InitialDelaySeconds: 30,
 	}
 	readinessProbe := &corev1.Probe{
 		// TODO might need tuning
 		TimeoutSeconds:      5,
 		PeriodSeconds:       5,
-		InitialDelaySeconds: 5,
+		InitialDelaySeconds: 30,
 	}
 
 	args := []string{"-c", ServiceCommand}

--- a/pkg/cloudkittyapi/volumes.go
+++ b/pkg/cloudkittyapi/volumes.go
@@ -35,7 +35,7 @@ func GetVolumeMounts(parentName string) []corev1.VolumeMount {
 	volumeMounts := []corev1.VolumeMount{
 		{
 			Name:      "config-data-custom",
-			MountPath: "/etc/cloudkitty/cloudkitty.conf.d",
+			MountPath: "/var/lib/openstack/service-config/",
 			ReadOnly:  true,
 		},
 		GetLogVolumeMount(),

--- a/pkg/cloudkittyproc/volumes.go
+++ b/pkg/cloudkittyproc/volumes.go
@@ -24,12 +24,12 @@ func GetVolumes(parentName string, name string) []corev1.Volume {
 	return append(cloudkitty.GetVolumes(parentName), volumes...)
 }
 
-// GetVolumeMounts - CloudKitty API VolumeMounts
+// GetVolumeMounts - CloudKitty Processor VolumeMounts
 func GetVolumeMounts(parentName string) []corev1.VolumeMount {
 	volumeMounts := []corev1.VolumeMount{
 		{
 			Name:      "config-data-custom",
-			MountPath: "/etc/cloudkitty/cloudkitty.conf.d",
+			MountPath: "/var/lib/openstack/service-config/",
 			ReadOnly:  true,
 		},
 	}

--- a/templates/cloudkitty/bin/healthcheck.py
+++ b/templates/cloudkitty/bin/healthcheck.py
@@ -117,7 +117,7 @@ if __name__ == "__main__":
 
     # Load configuration from file
     try:
-        cfg.CONF(sys.argv[1:], default_config_files=['/etc/cloudkitty/cloudkitty.conf.d/cloudkitty.conf'])
+        cfg.CONF(sys.argv[1:])
     except cfg.ConfigFilesNotFoundError as e:
         print(f"Health check failed: {e}", file=sys.stderr)
         sys.exit(1)

--- a/templates/cloudkitty/config/cloudkitty-api-config.json
+++ b/templates/cloudkitty/config/cloudkitty-api-config.json
@@ -2,17 +2,29 @@
   "command": "/usr/sbin/httpd -DFOREGROUND -E /dev/stdout",
   "config_files": [
     {
-      "source": "/var/lib/openstack/config/cloudkitty.conf",
-      "dest": "/etc/cloudkitty/cloudkitty.conf",
+      "source": "/var/lib/openstack/service-config/cloudkitty.conf",
+      "dest": "/etc/cloudkitty/cloudkitty.conf.d/00-cloudkitty.conf",
       "owner": "cloudkitty",
       "perm": "0600"
     },
     {
-      "source": "/var/lib/openstack/config/custom.conf",
-      "dest": "/etc/aodh/cloudkitty.conf.d/01-cloudkitty-custom.conf",
+      "source": "/var/lib/openstack/config/metrics.yaml",
+      "dest": "/etc/cloudkitty/metrics.yaml",
+      "owner": "cloudkitty",
+      "perm": "0600"
+    },
+    {
+      "source": "/var/lib/openstack/service-config/0*.conf",
+      "dest": "/etc/cloudkitty/cloudkitty.conf.d/",
       "owner": "cloudkitty",
       "perm": "0600",
       "optional": true
+    },
+    {
+      "source": "/var/lib/openstack/config/metrics.yaml",
+      "dest": "/etc/cloudkitty/metrics.yaml",
+      "owner": "cloudkitty",
+      "perm": "0600"
     },
     {
       "source": "/var/lib/openstack/config/wsgi-cloudkitty.conf",
@@ -67,7 +79,7 @@
   ],
   "permissions": [
       {
-          "path": "/var/log/cinder",
+          "path": "/var/log/cloudkitty",
           "owner": "cloudkitty:apache",
           "recurse": true
       },

--- a/templates/cloudkitty/config/cloudkitty-proc-config.json
+++ b/templates/cloudkitty/config/cloudkitty-proc-config.json
@@ -2,16 +2,55 @@
   "command": "/usr/bin/cloudkitty-processor --logfile /dev/stdout",
   "config_files": [
     {
-      "source": "/var/lib/openstack/config/cloudkitty.conf",
-      "dest": "/etc/cloudkitty/cloudkitty.conf",
+      "source": "/var/lib/openstack/service-config/cloudkitty.conf",
+      "dest": "/etc/cloudkitty/cloudkitty.conf.d/00-cloudkitty.conf",
       "owner": "cloudkitty",
       "perm": "0600"
+    },
+    {
+      "source": "/var/lib/openstack/service-config/0*.conf",
+      "dest": "/etc/cloudkitty/cloudkitty.conf.d/",
+      "owner": "cloudkitty",
+      "perm": "0600",
+      "optional": true
     },
     {
       "source": "/var/lib/openstack/config/metrics.yaml",
       "dest": "/etc/cloudkitty/metrics.yaml",
       "owner": "cloudkitty",
       "perm": "0600"
+    },
+    {
+      "source": "/var/lib/config-data/tls/certs/*",
+      "dest": "/etc/pki/tls/certs/",
+      "owner": "cloudkitty",
+      "perm": "0640",
+      "optional": true,
+      "merge": true
+    },
+    {
+      "source": "/var/lib/config-data/tls/private/*",
+      "dest": "/etc/pki/tls/private/",
+      "owner": "cloudkitty",
+      "perm": "0600",
+      "optional": true,
+      "merge": true
+    },
+    {
+      "source": "/var/lib/config-data/mtls/certs/*",
+      "dest": "/etc/pki/tls/certs/",
+      "owner": "cloudkitty:cloudkitty",
+      "perm": "0640",
+      "optional": true,
+      "merge": true
+    },
+    {
+      "source": "/var/lib/config-data/mtls/private/*",
+      "dest": "/etc/pki/tls/private/",
+      "owner": "cloudkitty:cloudkitty",
+      "perm": "0640",
+      "optional": true,
+      "merge": true
     }
   ]
 }

--- a/templates/cloudkitty/config/wsgi-cloudkitty.conf
+++ b/templates/cloudkitty/config/wsgi-cloudkitty.conf
@@ -34,7 +34,7 @@
   WSGIApplicationGroup %{GLOBAL}
   WSGIDaemonProcess {{ $endpt }} display-name={{ $endpt }} group=cloudkitty processes=4 threads=1 user=cloudkitty
   WSGIProcessGroup {{ $endpt }}
-  WSGIScriptAlias / "/var/www/cgi-bin/cloudkitty/cloudkitty-api"
+  WSGIScriptAlias / "/usr/bin/cloudkitty-api"
   WSGIPassAuthorization On
 </VirtualHost>
 {{ end }}


### PR DESCRIPTION
The healthcheck for cloudkitty-proc/probe was failing because the CA was not trusted. The TLS-related file were not available in the expected location in the container.

The kolla_set_config command is used so that the mounted config files get copied into the expected location for the healthcheck.

The command was updated to use 'bash -c' so that both the kolla_set_config and the healthcheck command would be run on startup.

[API] Update script used in uwsgi template

The script location changed between antelope and master containers. In both cases, it exists in the same alternative location

Update initial delay on liveness and readiness probes This give a chance for the api to start up before the first healthcheck

[API] Add metrics.yaml into the api pod