### PR TITLE
Fix issues after golang update

### DIFF
--- a/controllers/cloudkitty_controller.go
+++ b/controllers/cloudkitty_controller.go
@@ -716,7 +716,7 @@ func (r *CloudKittyReconciler) reconcileNormal(ctx context.Context, instance *te
 			telemetryv1.CloudKittyLokiStackReadyCondition,
 			condition.Reason(reason),
 			condition.SeverityWarning,
-			fmt.Sprintf("LokiStack issue: %s", message)))
+			"LokiStack issue: %s", message))
 	}
 
 	// Service account, role, binding

--- a/controllers/cloudkittyapi_controller.go
+++ b/controllers/cloudkittyapi_controller.go
@@ -793,7 +793,8 @@ func (r *CloudKittyAPIReconciler) reconcileNormal(ctx context.Context, instance 
 					condition.TLSInputReadyCondition,
 					condition.RequestedReason,
 					condition.SeverityInfo,
-					fmt.Sprintf(condition.TLSInputReadyWaitingMessage, instance.Spec.TLS.CaBundleSecretName)))
+					condition.TLSInputReadyWaitingMessage,
+					instance.Spec.TLS.CaBundleSecretName))
 				return ctrl.Result{}, nil
 			}
 			instance.Status.Conditions.Set(condition.FalseCondition(
@@ -818,7 +819,8 @@ func (r *CloudKittyAPIReconciler) reconcileNormal(ctx context.Context, instance 
 				condition.TLSInputReadyCondition,
 				condition.RequestedReason,
 				condition.SeverityInfo,
-				fmt.Sprintf(condition.TLSInputReadyWaitingMessage, err.Error())))
+				condition.TLSInputReadyWaitingMessage,
+				err.Error()))
 			return ctrl.Result{}, nil
 		}
 		instance.Status.Conditions.Set(condition.FalseCondition(

--- a/controllers/cloudkittyproc_controller.go
+++ b/controllers/cloudkittyproc_controller.go
@@ -480,7 +480,8 @@ func (r *CloudKittyProcReconciler) reconcileNormal(ctx context.Context, instance
 					condition.TLSInputReadyCondition,
 					condition.RequestedReason,
 					condition.SeverityInfo,
-					fmt.Sprintf(condition.TLSInputReadyWaitingMessage, instance.Spec.TLS.CaBundleSecretName)))
+					condition.TLSInputReadyWaitingMessage,
+					instance.Spec.TLS.CaBundleSecretName))
 				return ctrl.Result{}, nil
 			}
 			instance.Status.Conditions.Set(condition.FalseCondition(


### PR DESCRIPTION
Fix "non-constant format string in call to
github.com/openstack-k8s-operators/lib-common/modules/common/condition.FalseCondition"

The condition.FalseCondition takes a <format string>, <optional additional arguments based on format string> as its last arguments, similarly to fmt.Sprintf already. So there is no need to use Sprintf.